### PR TITLE
Use HTTPS for CDN

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,8 +10,8 @@
 	<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 	<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
 
-	<link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-	<link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css" rel="stylesheet">
+	<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+	<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css" rel="stylesheet">
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
 
 	<link href="//cdn.rawgit.com/Lukas-W/font-linux/v{{ site.data.fl.version }}/assets/font-linux.css" rel="stylesheet">


### PR DESCRIPTION
Fix "mixed content" errors in Chrome, which currently prevents the stylesheet from downloading.
This occurs on https://lukas-w.github.io/font-linux/ (httpS).