### PR TITLE
Add Sabayon icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ fonts in your project and use the CSS classes listed below.
 
 Or just link to it using [RawGit](//rawgit.com) (served via [MaxCDN](//www.maxcdn.com)'s network):
 
-	<link href="//cdn.rawgit.com/Lukas-W/font-linux/v0.5/assets/font-linux.css" rel="stylesheet">
+	<link href="//cdn.rawgit.com/Lukas-W/font-linux/master/assets/font-linux.css" rel="stylesheet">
 
 Available logos are:
 

--- a/vectors/sabayon.svg
+++ b/vectors/sabayon.svg
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="512"
+   height="512"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="sabayon.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="165.04993"
+       x2="100.00018"
+       y1="34.88868"
+       x1="100.00018"
+       id="linearGradient3738"
+       xlink:href="#linearGradient3709"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3627">
+      <stop
+         id="stop3629"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3631"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3709">
+      <stop
+         id="stop3711"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#d7d7d7;stop-opacity:1;"
+         offset="0.6038298"
+         id="stop3740" />
+      <stop
+         id="stop3713"
+         offset="1"
+         style="stop-color:#606060;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3627"
+       id="linearGradient3135"
+       gradientUnits="userSpaceOnUse"
+       x1="123.67211"
+       y1="25.942951"
+       x2="107.85547"
+       y2="84.971458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3709"
+       id="linearGradient4439"
+       gradientUnits="userSpaceOnUse"
+       x1="100.00018"
+       y1="34.88868"
+       x2="100.00018"
+       y2="165.04993" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="221.30061"
+     inkscape:cy="41.533674"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1855"
+     inkscape:window-height="1056"
+     inkscape:window-x="1665"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-78.055597,207.15167)">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none"
+       d="m 335.64138,-207.14469 c -2.19626,-0.0149 -4.37749,-0.007 -6.58608,0.034 C 187.70629,-204.48892 75.337077,-87.77176 78.105678,53.58219 80.874277,194.93605 197.72121,307.42527 339.07021,304.80341 480.41925,302.18165 592.75447,185.46443 589.98589,44.110472 587.26053,-95.034764 474.00613,-206.20602 335.64138,-207.14469 z m -2.24062,72.03938 c 9.01441,0.26176 3.05756,12.26824 8.96248,14.36035 2.56404,14.37243 3.64747,30.86897 -0.88266,45.01612 -3.80046,10.141114 -21.86359,1.677278 -19.55452,-9.403822 0.19301,-4.16874 -5.2114,-13.215082 -0.0679,-16.193588 2.18655,-10.77679 -2.43364,-30.72304 11.5426,-33.77906 z m -2.24063,74.891078 c 13.53416,-0.36128 18.37042,11.539294 23.56048,21.184059 2.33965,17.229898 4.71035,34.5132875 7.23109,51.737992 -0.17272,20.691916 0.34263,41.75352 -0.23764,62.228175 -2.80699,4.773855 0.19034,13.038321 -1.96902,18.875541 -2.46932,4.623588 1.7529,6.973425 0.78082,11.508645 -8.55939,16.42895 7.15702,29.66147 22.67781,31.33475 30.62239,-5.281 50.72094,-31.7466 77.43724,-45.253761 16.96071,-6.098543 42.07668,11.336661 23.79812,27.430641 -7.96161,18.6254 -23.04958,32.78002 -39.88986,43.01315 -23.05106,16.41206 -49.06213,28.66271 -72.58256,44.3711 -14.55596,13.30865 -33.13347,24.45725 -53.70702,20.94642 -46.89128,-2.78716 -77.95809,-42.02712 -115.39202,-65.01198 -10.26002,-5.69588 -21.42064,-9.43387 -27.60038,-20.30139 -21.9613,-15.64842 1.565,-40.46441 22.64385,-32.76061 21.63154,-0.0607 37.38898,16.79906 57.54324,21.96488 13.15857,3.42479 34.11704,22.28276 42.16443,1.96903 6.04363,-2.10225 -0.0116,-3.92842 1.83323,-9.20012 1.3458,-48.753988 -3.45485,-98.335932 7.33295,-146.31939 4.4507,-13.030696 7.22969,-36.060572 24.37524,-37.717132 z M 531.96737,55.041989 c 1.55249,-0.0051 3.09478,0.329754 4.54913,0.84872 12.36615,13.837461 -10.80818,34.669876 -24.61288,37.615286 -8.49143,2.640272 -15.44808,-0.640856 -19.99586,-7.502688 -0.46193,1.110001 -1.52485,-0.970632 -0.78082,-1.42585 4.13324,-17.472417 24.17167,-26.16843 40.84043,-29.535468 z m -406.33335,20.60693 c 3.81987,0.0086 7.65751,0.0055 11.4747,0.03395 9.03056,5.25079 17.65188,10.681253 25.69924,17.687331 13.12015,6.70862 -2.50026,17.32034 -9.8791,18.97739 -16.5938,-3.70408 -23.37801,-22.396095 -27.29484,-36.69867 z"
+       id="path4777"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>


### PR DESCRIPTION
This adds a simplified logo for Sabayon.
cf issue #14 

I did not include the generated files yet, because I had the following error for the preview picture:
```
./compile.sh: 3: ./compile.sh: wkhtmltoimage: not found
```
(only wkhtmltopdf is currently in Ubuntu repositories)