### PR TITLE
add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "font-linux",
+  "description": "An icon font providing popular linux distros' logos",
+  "version": "0.9.0",
+  "style": "assets/font-linux.css",
+  "authors": [
+    "Lukas W (https://github.com/Lukas-W)"
+  ],
+  "license": "Unlicense",
+  "homepage": "https://github.com/Lukas-W/font-linux",
+  "repository": "https://github.com/Lukas-W/font-linux.git"
+}


### PR DESCRIPTION
This lets us install font-linux from GitHub using npm, and will also be required for publishing on npmjs.com. Similar to #21, but with the correct version and no bower.json because bower is dead. 